### PR TITLE
fix Invalid distribution name or version syntax: bev-mmdet3d--0.1 bug

### DIFF
--- a/third_party/bev_mmdet3d/setup.py
+++ b/third_party/bev_mmdet3d/setup.py
@@ -37,7 +37,7 @@ def make_cuda_ext(
 
 if __name__ == "__main__":
     setup(
-        name="bev_mmdet3d_",
+        name="bev_mmdet3d",
         version="0.1",
         packages=find_packages(),
         include_package_data=True,


### PR DESCRIPTION
### PR types
Bug fixes
### Describe
fix the error "Invalid distribution name or version syntax: bev-mmdet3d--0.1" bug